### PR TITLE
Install PyQt5 using apt instead of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To install PyCirkuit in you computer, please follow this steps:
 
          sudo apt-get install texlive-latex-base texlive-latex-recommended \
          texlive-base-bin texlive-extra-utils texlive-pictures preview-latex-style \
-         m4 dpic poppler-utils python3-venv qtcreator
+         m4 dpic poppler-utils python3-venv qtcreator python3-pyqt5
 
      <sup>1</sup> Apparently, Debian does not have ```dpic``` packaged, but Ubuntu has (in
      the *universe* repository). If you are trying PyCirkuit in a Debian system, you'll

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To run this application you need to have the following applications/libraries in
 
   * Qt5 libraries
   * Python 3, with virtual environment support
-  * PyQt5 python bindings to Qt libraries (*see note below*)
+  * PyQt5 python bindings to Qt libraries
   * (pdf)latex
   * m4
   * dpic
@@ -65,7 +65,7 @@ To install PyCirkuit in you computer, please follow this steps:
 
   3. Install PyCirkuit. You have several ways to do so. Choose one of the following:
   
-     3.1 PyCirkuit is available at the [Python Package Index (PyPI)](https://pypi.org/), so you can install it using PIP. It will download and install alongside the required dependencies (PyQt5). After installation, PyCirkuit code and files will be under
+     3.1 PyCirkuit is available at the [Python Package Index (PyPI)](https://pypi.org/), so you can install it using PIP. After installation, PyCirkuit code and files will be under
   ```PyCirkuit/lib/python3.X/site-packages/pycirkuit```
 
          pip install pycirkuit

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,4 @@ setup(name = 'pycirkuit',
         "Intended Audience :: Science/Research",
         "Intended Audience :: End Users/Desktop",
     ],
-    install_requires = [
-        'PyQt5'
-    ],
     zip_safe = True)


### PR DESCRIPTION
Using the available `PyQt5` version in the Debian repositories makes it easier to build a `pycirkuit` package.
Downloading Python packages from `pip` during the Debian package installation is almost forbidden.